### PR TITLE
fix: add missing border colors

### DIFF
--- a/8-trifecta/39-green-light-go/styles.css
+++ b/8-trifecta/39-green-light-go/styles.css
@@ -2,14 +2,14 @@
 /* Codédex */
 
 #traffic-light-div {
-  border: 7px solid;
+  border: 7px solid black;
   width: 150px;
   height: 400px;
   background-color: grey;
 }
 
 .light {
-  border: 3px solid;
+  border: 3px solid black;
   width: 100px;
   height: 100px;
   margin: 20px auto;


### PR DESCRIPTION
## Fix: Missing `border` **colors** in `39-green-light-go`
- This PR fixes an **inconsistency** with `border` **colors** that are available across all exercises in [8-trifecta](https://github.com/beingsie/javascript-101/blob/main/8-trifecta/) except exercise `39-green-light-go`.

### Changes:
- Added `border` **colors** to `#traffic-light-div` and `.light`.

### Screenshot with fixes:
<img width="305" alt="image" src="https://github.com/codedex-io/javascript-101/assets/140430987/0130adda-7bee-4ae9-b34d-393ab0648d49">

### Related issues:
- This PR closes #35.
