### PR TITLE
Fix: Remove Whitespace from Grocery List Item

### DIFF
--- a/5-arrays/24-grocery-trip.js
+++ b/5-arrays/24-grocery-trip.js
@@ -1,7 +1,7 @@
 // Grocery Trip 🛒
 // Codédex
 
-let groceryList = ["🥛 Milk", "🥑 Avocado", "🥚 Eggs ", "🍞 Bread"];
+let groceryList = ["🥛 Milk", "🥑 Avocado", "🥚 Eggs", "🍞 Bread"];
 
 groceryList[2] = "🧈 Butter";
 

--- a/7-objects/36-pokemon.js
+++ b/7-objects/36-pokemon.js
@@ -1,7 +1,7 @@
 // Pokémon 📟
 // Codédex
 
-pokemon = {
+const pokemon = {
   name: "Pikachu",
   type: "Electric",
   level: 25,


### PR DESCRIPTION
PR Description:
Overview:
This pull request addresses a minor issue in the grocery list array within the "Grocery Trip" code.

Problem:
The item for eggs in the grocery list contained an extra whitespace character, which could lead to inconsistencies when searching for or comparing items in the list. The original entry was:
"🥚 Eggs "
Solution:
I have removed the extra space from the "Eggs" entry to ensure consistency. The updated entry is now:
"🥚 Eggs"