### PR TITLE
fix: clear 'binary' before reuse and add console logs

### DIFF
--- a/4-loops/22-based-numbers.js
+++ b/4-loops/22-based-numbers.js
@@ -12,15 +12,19 @@ for (let i = myNumber; i >= 1 ; i = Math.floor(i/2)) {
     binary = "1" + binary;
   }
 }
+console.log('With for loop: ' + binary);
 
 // With while loop
 let i = myNumber;
+binary = "";
 while (i >= 1) {
   if (i % 2 == 0) {
     binary = "0" + binary;
   } else {
     binary = "1" + binary;
   }
-  
+
   i = Math.floor(i/2);
 }
+
+console.log('With while loop: ' + binary);


### PR DESCRIPTION
- **Clear 'binary' before using it again.**

The _binary_ variable was accumulating the results from both loops, causing the first loop to produce a result while the second loop contained the accumulation of both. Now, before starting the second loop, the variable is cleared to ensure it yields the same result as the first loop.

- **Add console logs to visualize the results better.**

Console logs have been added to visualize and compare the results of both loops more effectively.