### PR TITLE
fix: handle invalid AQI input and improve condition coverage

### DIFF
--- a/3-conditionals/16-air-quality-index.js
+++ b/3-conditionals/16-air-quality-index.js
@@ -13,6 +13,8 @@ if (aqi >= 0 && aqi <= 50) {
   console.log("Unhealthy");
 } else if (aqi >= 201 && aqi <= 300) {
   console.log("Very Unhealthy");
-} else {
+} else if (aqi >= 301) {
   console.log("Hazardous");
+} else {
+  console.log("Wrong Input, Try Again!");
 }


### PR DESCRIPTION
Updated AQI evaluation logic to explicitly handle values ≥301 as "Hazardous" and added a fallback condition for invalid inputs (e.g., negative values or non-numeric data).